### PR TITLE
Add an option to parse all worksheets in one function call

### DIFF
--- a/sheet2dict/main.py
+++ b/sheet2dict/main.py
@@ -51,10 +51,10 @@ class Worksheet:
                 str(sheet.cell(row=row, column=col).value),
             )
 
+        list_to_append = (
+            self.sheet_items[sheet_title] if parsing_all_sheets else self.sheet_items
+        )
         for row in range(2, rows + 1):
-            list_to_append = (
-                self.sheet_items[sheet_title] if parsing_all_sheets else self.sheet_items
-            )
             list_to_append.append(dict(item(row, col) for col in range(1, cols + 1)))
 
     def csv_to_dict(self, csv_file, delimiter=","):

--- a/tests/test_1_xlsx.py
+++ b/tests/test_1_xlsx.py
@@ -37,6 +37,17 @@ def test_parse_xlsx_sheet_items(worksheet):
     assert len(ws_items) > 1
     assert len(ws_items) == 6
 
+def test_parse_xlsx_all_sheets(worksheet):
+    ws = worksheet
+    ws.xlsx_to_dict(path="tests/inventory.xlsx", parse_all_sheets=True)
+    ws_items = ws.sheet_items
+    assert "Sheet1" in ws_items
+    assert "SJ3" in ws_items
+    assert "Taiwan" in str(ws_items["SJ3"])
+    assert "Miami" in str(ws_items["SJ3"])
+    assert "Bratislava" in str(ws_items["Sheet1"])
+    assert "Prague" in str(ws_items["Sheet1"])
+
 
 def test_sanitize_sheet_items(worksheet):
     ws = worksheet
@@ -70,3 +81,15 @@ def test_parse_xlsx_sheet_items_as_object(worksheet):
     assert "Miami" in str(ws_items)
     assert len(ws_items) > 1
     assert len(ws_items) == 6
+
+
+def test_parse_xlsx_all_sheets_as_object(worksheet):
+    ws = worksheet
+    ws.xlsx_to_dict(path=xlsx_file, parse_all_sheets=True)
+    ws_items = ws.sheet_items
+    assert "Sheet1" in ws_items
+    assert "SJ3" in ws_items
+    assert "Taiwan" in str(ws_items["SJ3"])
+    assert "Miami" in str(ws_items["SJ3"])
+    assert "Bratislava" in str(ws_items["Sheet1"])
+    assert "Prague" in str(ws_items["Sheet1"])


### PR DESCRIPTION
Added an option to parse all sheets from a workbook at once while keeping the way existing features worked untouched.

Had to modify `sheet_items` to a dict with sheet names as keys and sheet's objects as values. 